### PR TITLE
Dont set up chart if canvas is not rendered.

### DIFF
--- a/src/wwwroot/Chart.js
+++ b/src/wwwroot/Chart.js
@@ -44,10 +44,13 @@
 }
 
 export function chartSetup(id, dotnetConfig, jsonConfig) {
-    document.getElementById("chartcontainer" + id).style.display = 'none';
-    document.getElementById("chartcontainer" + id).innerHTML = '&nbsp;';
-    document.getElementById("chartcontainer" + id).innerHTML = '<canvas id="' + id + '"></canvas>';
-    document.getElementById("chartcontainer" + id).style.display = '';
+    let chartElement = document.getElementById("chartcontainer" + id);
+    if (!chartElement) return;
+
+    chartElement.style.display = 'none';
+    chartElement.innerHTML = '&nbsp;';
+    chartElement.innerHTML = '<canvas id="' + id + '"></canvas>';
+    chartElement.style.display = '';
 
     var context2d = document.getElementById(id).getContext('2d');
     let config = eval(jsonConfig);


### PR DESCRIPTION
The chart resulted in a null reference exception if the <Chart> element was optionally rendered on the Blazor page.

I was rendering a chart with the following markup:
`@if (_config1 is not null) {
  <Chart Config="_config1"></Chart>
}`

This results in a timing issue where the chart setup code is executed before the chart is rendered.
When chart.js/chartSetup was executed, the element returned null resulting in an error that style was not defined on a null reference.

This pull request protects against this happening, stopping the chart from being set up at all unless the chart container is found by the browser on the page by checking for the existence of the element first.

Kind regards,
Adrian.