### PR TITLE
Add type module to use export

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fist, you have to add the component from [NuGet](https://www.nuget.org/packages/
 
 ```
 <script src="_content/PSC.Blazor.Components.Chartjs/lib/Chart.js/chart.js"></script>
-<script src="_content/PSC.Blazor.Components.Chartjs/Chart.js"></script>
+<script src="_content/PSC.Blazor.Components.Chartjs/Chart.js" type="module"></script>
 ```
 
 The first script is the Chart.js library version 3.7.1 because I'm using this version to create the components. You can use other sources for it but maybe you can face issues in other versions.


### PR DESCRIPTION
Either the readme has to change, or the export keyword has to be removed from the Chart.js file. Right now if you don't specify the type="module" then you receive the error below in the console.

![image](https://github.com/erossini/BlazorChartjs/assets/1436449/db3c26f9-06fa-4d05-ae57-c28897e5f5ba)
