### PR TITLE
Added Legend Labels Filtering. Added support to Ticks' AutoSkip and Font properties. 

### DIFF
--- a/ChartjsDemo/ChartjsDemo.csproj
+++ b/ChartjsDemo/ChartjsDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>

--- a/src/Chart.razor.cs
+++ b/src/Chart.razor.cs
@@ -5,7 +5,8 @@ using PSC.Blazor.Components.Chartjs.Models.Bar;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs {
+namespace PSC.Blazor.Components.Chartjs 
+{
     /// <summary>
     /// Class Chart.
     /// Implements the <see cref="ComponentBase" />
@@ -13,7 +14,8 @@ namespace PSC.Blazor.Components.Chartjs {
     /// </summary>
     /// <seealso cref="ComponentBase" />
     /// <seealso cref="System.IDisposable" />
-    public partial class Chart : IDisposable {
+    public partial class Chart : IDisposable 
+    {
         #region .NET Object references
 
         /// <summary>
@@ -110,11 +112,13 @@ namespace PSC.Blazor.Components.Chartjs {
 
         #region Public functions
 
-        public async void AddData(List<string?> labels, int datasetIndex, List<decimal?> data) {
+        public async void AddData(List<string?> labels, int datasetIndex, List<decimal?> data) 
+        {
             await JSModule.AddData(Config.CanvasId, labels, datasetIndex, data);
         }
 
-        public async void AddDataset<T>(T dataset) where T : class {
+        public async void AddDataset<T>(T dataset) where T : class 
+        {
             await JSModule.AddNewDataset(Config.CanvasId, dataset);
         }
 
@@ -122,9 +126,12 @@ namespace PSC.Blazor.Components.Chartjs {
 
         #endregion Parameters
 
-        protected override async Task OnAfterRenderAsync(bool firstRender) {
-            if (Config != null) {
-                if (OldConfig == null || Config != OldConfig) {
+        protected override async Task OnAfterRenderAsync(bool firstRender) 
+        {
+            if (Config != null) 
+            {
+                if (OldConfig == null || Config != OldConfig) 
+                {
                     var dotNetObjectRef = DotNetObjectReference.Create(Config);
 
                     JSModule = new ChartJsInterop(JSRuntime);
@@ -135,7 +142,8 @@ namespace PSC.Blazor.Components.Chartjs {
             }
         }
 
-        private ValueTask OnMouseOutAsync(MouseEventArgs mouseEventArgs) {
+        private ValueTask OnMouseOutAsync(MouseEventArgs mouseEventArgs) 
+        {
             if (Config.Options is Options { OnMouseOutAsync: { } } options)
                 return options.OnMouseOutAsync(mouseEventArgs);
             else
@@ -145,7 +153,8 @@ namespace PSC.Blazor.Components.Chartjs {
         #region JavaScript invokable functions
 
         [JSInvokable]
-        public static string[] TitleCallbacks(DotNetObjectReference<IChartConfig> config, decimal[] parameters) {
+        public static string[] TitleCallbacks(DotNetObjectReference<IChartConfig> config, decimal[] parameters) 
+        {
             var ctx = new CallbackGenericContext((int)parameters[0], (int)parameters[1], parameters[2]);
             if (config.Value.Options is Options options)
                 return options.Plugins.Tooltip.Callbacks.Title(ctx);
@@ -154,7 +163,8 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static string[] TooltipCallbacksLabel(DotNetObjectReference<IChartConfig> config, int[] parameters) {
+        public static string[] TooltipCallbacksLabel(DotNetObjectReference<IChartConfig> config, int[] parameters) 
+        {
             var ctx = new CallbackGenericContext(parameters[0], parameters[1], parameters[2]);
             if (config.Value.Options is Options options)
                 return options.Plugins.Tooltip.Callbacks.Label(ctx);
@@ -163,7 +173,8 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static bool? LegendLabelsFilter(DotNetObjectReference<IChartConfig> config, LegendItem item, Data data) {
+        public static bool? LegendLabelsFilter(DotNetObjectReference<IChartConfig> config, LegendItem item, Data data) 
+        {
             var ctx = new LegendFilterContext(item, data);
             if (config.Value.Options is Options options)
                 return options.Plugins.Legend.Labels.Filter(ctx);
@@ -172,7 +183,8 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnClickAsync(DotNetObjectReference<IChartConfig> config, CallbackGenericContext ctx) {
+        public static async Task<ValueTask> OnClickAsync(DotNetObjectReference<IChartConfig> config, CallbackGenericContext ctx) 
+        {
             //await OnChartClick.InvokeAsync(ctx);
 
             if (config.Value.Options is Options options && options.OnClickAsync != null)
@@ -182,7 +194,8 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnHoverAsync(DotNetObjectReference<IChartConfig> config, HoverContext ctx) {
+        public static async Task<ValueTask> OnHoverAsync(DotNetObjectReference<IChartConfig> config, HoverContext ctx) 
+        {
             if (config.Value.Options is Options options && options.OnHoverAsync != null)
                 return options.OnHoverAsync(ctx);
             else
@@ -190,7 +203,8 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnLegendClickAsync(DotNetObjectReference<IChartConfig> config, LegendClickContext ctx) {
+        public static async Task<ValueTask> OnLegendClickAsync(DotNetObjectReference<IChartConfig> config, LegendClickContext ctx) 
+        {
             if (config.Value.Options is Options options && options?.Plugins?.Legend?.OnClickAsync != null)
                 return options.Plugins.Legend.OnClickAsync(ctx);
             else
@@ -199,7 +213,8 @@ namespace PSC.Blazor.Components.Chartjs {
 
         #endregion JavaScript invokable functions
 
-        public void Dispose() {
+        public void Dispose() 
+        {
         }
     }
 }

--- a/src/Chart.razor.cs
+++ b/src/Chart.razor.cs
@@ -1,10 +1,10 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs
-{
+namespace PSC.Blazor.Components.Chartjs {
     /// <summary>
     /// Class Chart.
     /// Implements the <see cref="ComponentBase" />
@@ -12,8 +12,7 @@ namespace PSC.Blazor.Components.Chartjs
     /// </summary>
     /// <seealso cref="ComponentBase" />
     /// <seealso cref="System.IDisposable" />
-    public partial class Chart : IDisposable
-    {
+    public partial class Chart : IDisposable {
         #region .NET Object references
 
         /// <summary>
@@ -110,13 +109,11 @@ namespace PSC.Blazor.Components.Chartjs
 
         #region Public functions
 
-        public async void AddData(List<string?> labels, int datasetIndex, List<decimal?> data)
-        {
+        public async void AddData(List<string?> labels, int datasetIndex, List<decimal?> data) {
             await JSModule.AddData(Config.CanvasId, labels, datasetIndex, data);
         }
 
-        public async void AddDataset<T>(T dataset) where T : class
-        {
+        public async void AddDataset<T>(T dataset) where T : class {
             await JSModule.AddNewDataset(Config.CanvasId, dataset);
         }
 
@@ -124,12 +121,9 @@ namespace PSC.Blazor.Components.Chartjs
 
         #endregion Parameters
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
-        {
-            if (Config != null)
-            {
-                if (OldConfig == null || Config != OldConfig)
-                {
+        protected override async Task OnAfterRenderAsync(bool firstRender) {
+            if (Config != null) {
+                if (OldConfig == null || Config != OldConfig) {
                     var dotNetObjectRef = DotNetObjectReference.Create(Config);
 
                     JSModule = new ChartJsInterop(JSRuntime);
@@ -140,8 +134,7 @@ namespace PSC.Blazor.Components.Chartjs
             }
         }
 
-        private ValueTask OnMouseOutAsync(MouseEventArgs mouseEventArgs)
-        {
+        private ValueTask OnMouseOutAsync(MouseEventArgs mouseEventArgs) {
             if (Config.Options is Options { OnMouseOutAsync: { } } options)
                 return options.OnMouseOutAsync(mouseEventArgs);
             else
@@ -151,8 +144,7 @@ namespace PSC.Blazor.Components.Chartjs
         #region JavaScript invokable functions
 
         [JSInvokable]
-        public static string[] TitleCallbacks(DotNetObjectReference<IChartConfig> config, decimal[] parameters)
-        {
+        public static string[] TitleCallbacks(DotNetObjectReference<IChartConfig> config, decimal[] parameters) {
             var ctx = new CallbackGenericContext((int)parameters[0], (int)parameters[1], parameters[2]);
             if (config.Value.Options is Options options)
                 return options.Plugins.Tooltip.Callbacks.Title(ctx);
@@ -161,8 +153,7 @@ namespace PSC.Blazor.Components.Chartjs
         }
 
         [JSInvokable]
-        public static string[] TooltipCallbacksLabel(DotNetObjectReference<IChartConfig> config, int[] parameters)
-        {
+        public static string[] TooltipCallbacksLabel(DotNetObjectReference<IChartConfig> config, int[] parameters) {
             var ctx = new CallbackGenericContext(parameters[0], parameters[1], parameters[2]);
             if (config.Value.Options is Options options)
                 return options.Plugins.Tooltip.Callbacks.Label(ctx);
@@ -171,8 +162,16 @@ namespace PSC.Blazor.Components.Chartjs
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnClickAsync(DotNetObjectReference<IChartConfig> config, CallbackGenericContext ctx)
-        {
+        public static bool? LegendLabelsFilter(DotNetObjectReference<IChartConfig> config, LegendItem item, Data<Dataset> data) {
+            var ctx = new LegendFilterContext(item, data);
+            if (config.Value.Options is Options options)
+                return options.Plugins.Legend.Labels.Filter(ctx);
+            else
+                throw new NotSupportedException();
+        }
+
+        [JSInvokable]
+        public static async Task<ValueTask> OnClickAsync(DotNetObjectReference<IChartConfig> config, CallbackGenericContext ctx) {
             //await OnChartClick.InvokeAsync(ctx);
 
             if (config.Value.Options is Options options && options.OnClickAsync != null)
@@ -182,8 +181,7 @@ namespace PSC.Blazor.Components.Chartjs
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnHoverAsync(DotNetObjectReference<IChartConfig> config, HoverContext ctx)
-        {
+        public static async Task<ValueTask> OnHoverAsync(DotNetObjectReference<IChartConfig> config, HoverContext ctx) {
             if (config.Value.Options is Options options && options.OnHoverAsync != null)
                 return options.OnHoverAsync(ctx);
             else
@@ -191,8 +189,7 @@ namespace PSC.Blazor.Components.Chartjs
         }
 
         [JSInvokable]
-        public static async Task<ValueTask> OnLegendClickAsync(DotNetObjectReference<IChartConfig> config, LegendClickContext ctx)
-        {
+        public static async Task<ValueTask> OnLegendClickAsync(DotNetObjectReference<IChartConfig> config, LegendClickContext ctx) {
             if (config.Value.Options is Options options && options?.Plugins?.Legend?.OnClickAsync != null)
                 return options.Plugins.Legend.OnClickAsync(ctx);
             else
@@ -201,8 +198,7 @@ namespace PSC.Blazor.Components.Chartjs
 
         #endregion JavaScript invokable functions
 
-        public void Dispose()
-        {
+        public void Dispose() {
         }
     }
 }

--- a/src/Chart.razor.cs
+++ b/src/Chart.razor.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using PSC.Blazor.Components.Chartjs.Models.Bar;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -162,7 +163,7 @@ namespace PSC.Blazor.Components.Chartjs {
         }
 
         [JSInvokable]
-        public static bool? LegendLabelsFilter(DotNetObjectReference<IChartConfig> config, LegendItem item, Data<Dataset> data) {
+        public static bool? LegendLabelsFilter(DotNetObjectReference<IChartConfig> config, LegendItem item, Data data) {
             var ctx = new LegendFilterContext(item, data);
             if (config.Value.Options is Options options)
                 return options.Plugins.Legend.Labels.Filter(ctx);

--- a/src/ChartJsInterop.cs
+++ b/src/ChartJsInterop.cs
@@ -2,26 +2,32 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs {
-    public class ChartJsInterop {
+namespace PSC.Blazor.Components.Chartjs 
+{
+    public class ChartJsInterop 
+    {
         private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 
-        public ChartJsInterop(IJSRuntime jsRuntime) {
+        public ChartJsInterop(IJSRuntime jsRuntime) 
+        {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import",
                 "./_content/PSC.Blazor.Components.Chartjs/Chart.js").AsTask());
         }
 
-        public async ValueTask Setup(DotNetObjectReference<IChartConfig> dotNetObjectRef, IChartConfig Config) {
+        public async ValueTask Setup(DotNetObjectReference<IChartConfig> dotNetObjectRef, IChartConfig Config) 
+        {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("chartSetup", Config.CanvasId, dotNetObjectRef, Config);
         }
 
-        public async ValueTask AddData(string CanvasId, List<string> labels, int datasetIndex, List<decimal?> data) {
+        public async ValueTask AddData(string CanvasId, List<string> labels, int datasetIndex, List<decimal?> data) 
+        {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("addData", CanvasId, labels, datasetIndex, data);
         }
 
-        public async ValueTask AddNewDataset<T>(string CanvasId, T dataset) where T : class {
+        public async ValueTask AddNewDataset<T>(string CanvasId, T dataset) where T : class 
+        {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("addNewDataset", CanvasId, dataset);
         }

--- a/src/ChartJsInterop.cs
+++ b/src/ChartJsInterop.cs
@@ -1,32 +1,27 @@
 ﻿using Microsoft.JSInterop;
+using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs
-{
-    public class ChartJsInterop
-    {
+namespace PSC.Blazor.Components.Chartjs {
+    public class ChartJsInterop {
         private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 
-        public ChartJsInterop(IJSRuntime jsRuntime)
-        {
+        public ChartJsInterop(IJSRuntime jsRuntime) {
             moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import",
                 "./_content/PSC.Blazor.Components.Chartjs/Chart.js").AsTask());
         }
 
-        public async ValueTask Setup(DotNetObjectReference<IChartConfig> dotNetObjectRef, IChartConfig Config)
-        {
+        public async ValueTask Setup(DotNetObjectReference<IChartConfig> dotNetObjectRef, IChartConfig Config) {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("chartSetup", Config.CanvasId, dotNetObjectRef, Config);
         }
 
-        public async ValueTask AddData(string CanvasId, List<string> labels, int datasetIndex, List<decimal?> data)
-        {
+        public async ValueTask AddData(string CanvasId, List<string> labels, int datasetIndex, List<decimal?> data) {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("addData", CanvasId, labels, datasetIndex, data);
         }
 
-        public async ValueTask AddNewDataset<T>(string CanvasId, T dataset) where T : class
-        {
+        public async ValueTask AddNewDataset<T>(string CanvasId, T dataset) where T : class {
             var module = await moduleTask.Value;
             await module.InvokeVoidAsync("addNewDataset", CanvasId, dataset);
         }

--- a/src/Interfaces/IChartConfig.cs
+++ b/src/Interfaces/IChartConfig.cs
@@ -7,8 +7,10 @@ using PSC.Blazor.Components.Chartjs.Models.Polar;
 using PSC.Blazor.Components.Chartjs.Models.Radar;
 using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
-namespace PSC.Blazor.Components.Chartjs.Interfaces {
-    public interface IChartConfig {
+namespace PSC.Blazor.Components.Chartjs.Interfaces 
+{
+    public interface IChartConfig 
+    {
         string CanvasId { get; }
         string Type { get; set; }
         IOptions Options { get; }

--- a/src/Interfaces/IChartConfig.cs
+++ b/src/Interfaces/IChartConfig.cs
@@ -1,7 +1,14 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Interfaces
-{
-    public interface IChartConfig
-    {
+﻿using PSC.Blazor.Components.Chartjs.Models.Bar;
+using PSC.Blazor.Components.Chartjs.Models.Bubble;
+using PSC.Blazor.Components.Chartjs.Models.Doughnut;
+using PSC.Blazor.Components.Chartjs.Models.Line;
+using PSC.Blazor.Components.Chartjs.Models.Pie;
+using PSC.Blazor.Components.Chartjs.Models.Polar;
+using PSC.Blazor.Components.Chartjs.Models.Radar;
+using PSC.Blazor.Components.Chartjs.Models.Scatter;
+
+namespace PSC.Blazor.Components.Chartjs.Interfaces {
+    public interface IChartConfig {
         string CanvasId { get; }
         string Type { get; set; }
         IOptions Options { get; }

--- a/src/Interfaces/IOptions.cs
+++ b/src/Interfaces/IOptions.cs
@@ -1,10 +1,12 @@
 ﻿using PSC.Blazor.Components.Chartjs.Models.Pie;
 using PSC.Blazor.Components.Chartjs.Models.Radar;
 
-namespace PSC.Blazor.Components.Chartjs.Interfaces {
+namespace PSC.Blazor.Components.Chartjs.Interfaces 
+{
     /// <summary>
     /// IOptions
     /// </summary>
-    public interface IOptions {
+    public interface IOptions 
+    {
     }
 }

--- a/src/Interfaces/IOptions.cs
+++ b/src/Interfaces/IOptions.cs
@@ -1,9 +1,10 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Interfaces
-{
+﻿using PSC.Blazor.Components.Chartjs.Models.Pie;
+using PSC.Blazor.Components.Chartjs.Models.Radar;
+
+namespace PSC.Blazor.Components.Chartjs.Interfaces {
     /// <summary>
     /// IOptions
     /// </summary>
-    public interface IOptions
-    {
+    public interface IOptions {
     }
 }

--- a/src/Models/Bubble/BubbleData.cs
+++ b/src/Models/Bubble/BubbleData.cs
@@ -1,4 +1,6 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Bubble {
-    public class BubbleData : Data<BubbleDataset> {
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Bubble 
+{
+    public class BubbleData : Data<BubbleDataset> 
+    {
     }
 }

--- a/src/Models/Bubble/BubbleData.cs
+++ b/src/Models/Bubble/BubbleData.cs
@@ -1,6 +1,4 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Bubble
-{
-    public class BubbleData : Data<BubbleDataset>
-    {
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Bubble {
+    public class BubbleData : Data<BubbleDataset> {
     }
 }

--- a/src/Models/Common/Context/LegendFilterContext.cs
+++ b/src/Models/Common/Context/LegendFilterContext.cs
@@ -1,0 +1,4 @@
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
+    public readonly record struct LegendFilterContext(LegendItem Item, Data<Dataset> Data) {
+    }
+}

--- a/src/Models/Common/Context/LegendFilterContext.cs
+++ b/src/Models/Common/Context/LegendFilterContext.cs
@@ -1,4 +1,4 @@
 namespace PSC.Blazor.Components.Chartjs.Models.Common {
-    public readonly record struct LegendFilterContext(LegendItem Item, Data<Dataset> Data) {
+    public readonly record struct LegendFilterContext(LegendItem Item, Data Data) {
     }
 }

--- a/src/Models/Common/Context/LegendFilterContext.cs
+++ b/src/Models/Common/Context/LegendFilterContext.cs
@@ -1,4 +1,6 @@
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
-    public readonly record struct LegendFilterContext(LegendItem Item, Data Data) {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
+    public readonly record struct LegendFilterContext(LegendItem Item, Data Data) 
+    {
     }
 }

--- a/src/Models/Common/CustomDataset.cs
+++ b/src/Models/Common/CustomDataset.cs
@@ -1,11 +1,13 @@
 ﻿using PSC.Blazor.Components.Chartjs.Models.Bubble;
 using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     [JsonDerivedType(typeof(CustomDataset), typeDiscriminator: "base")]
     [JsonDerivedType(typeof(BubbleDataset), typeDiscriminator: "bubbleData")]
     [JsonDerivedType(typeof(ScatterDataset), typeDiscriminator: "scatterData")]
-    public class CustomDataset {
+    public class CustomDataset 
+    {
         /// <summary>
         /// Gets or sets the label.
         /// </summary>
@@ -19,7 +21,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Datatset for charts
     /// </summary>
-    public class CustomDataset<T> : CustomDataset where T : class {
+    public class CustomDataset<T> : CustomDataset where T : class 
+    {
         /// <summary>
         /// Gets or sets the data.
         /// </summary>

--- a/src/Models/Common/CustomDataset.cs
+++ b/src/Models/Common/CustomDataset.cs
@@ -1,20 +1,11 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
-    /// <summary>
-    /// Datatset for charts
-    /// </summary>
-    public class CustomDataset<T> where T : class
-    {
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        [JsonPropertyName("data")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public virtual List<T> Data { get; set; }
+﻿using PSC.Blazor.Components.Chartjs.Models.Bubble;
+using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
+    [JsonDerivedType(typeof(CustomDataset), typeDiscriminator: "base")]
+    [JsonDerivedType(typeof(BubbleDataset), typeDiscriminator: "bubbleData")]
+    [JsonDerivedType(typeof(ScatterDataset), typeDiscriminator: "scatterData")]
+    public class CustomDataset {
         /// <summary>
         /// Gets or sets the label.
         /// </summary>
@@ -24,5 +15,19 @@
         [JsonPropertyName("label")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Label { get; set; }
+    }
+    /// <summary>
+    /// Datatset for charts
+    /// </summary>
+    public class CustomDataset<T> : CustomDataset where T : class {
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>
+        /// The data.
+        /// </value>
+        [JsonPropertyName("data")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public virtual List<T> Data { get; set; }
     }
 }

--- a/src/Models/Common/Data.cs
+++ b/src/Models/Common/Data.cs
@@ -7,7 +7,8 @@ using PSC.Blazor.Components.Chartjs.Models.Polar;
 using PSC.Blazor.Components.Chartjs.Models.Radar;
 using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Data for Charts
     /// </summary>
@@ -20,7 +21,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
     [JsonDerivedType(typeof(RadarData), typeDiscriminator: "radarData")]
     [JsonDerivedType(typeof(BubbleData), typeDiscriminator: "bubbleData")]
     [JsonDerivedType(typeof(ScatterData), typeDiscriminator: "scatterData")]
-    public class Data {
+    public class Data 
+    {
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
@@ -35,7 +37,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Data for Charts
     /// </summary>
-    public class Data<T> : Data where T : class {
+    public class Data<T> : Data where T : class 
+    {
         /// <summary>
         /// Gets or sets the datasets.
         /// </summary>

--- a/src/Models/Common/Data.cs
+++ b/src/Models/Common/Data.cs
@@ -1,20 +1,24 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
-    /// <summary>
-    /// Data for Bar
-    /// </summary>
-    public class Data<T> where T : class
-    {
-        /// <summary>
-        /// Gets or sets the datasets.
-        /// </summary>
-        /// <value>
-        /// The datasets.
-        /// </value>
-        [JsonPropertyName("datasets")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public List<T> Datasets { get; set; } = new List<T>();
+﻿using PSC.Blazor.Components.Chartjs.Models.Bar;
+using PSC.Blazor.Components.Chartjs.Models.Bubble;
+using PSC.Blazor.Components.Chartjs.Models.Doughnut;
+using PSC.Blazor.Components.Chartjs.Models.Line;
+using PSC.Blazor.Components.Chartjs.Models.Pie;
+using PSC.Blazor.Components.Chartjs.Models.Polar;
+using PSC.Blazor.Components.Chartjs.Models.Radar;
+using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
+    /// <summary>
+    /// Data for Charts
+    /// </summary>
+    [JsonDerivedType(typeof(Data), typeDiscriminator: "base")]
+    [JsonDerivedType(typeof(BarData), typeDiscriminator: "barData")]
+    [JsonDerivedType(typeof(DoughnutData), typeDiscriminator: "doughnutData")]
+    [JsonDerivedType(typeof(LineData), typeDiscriminator: "lineData")]
+    [JsonDerivedType(typeof(PieData), typeDiscriminator: "pieData")]
+    [JsonDerivedType(typeof(PolarData), typeDiscriminator: "polarData")]
+    [JsonDerivedType(typeof(RadarData), typeDiscriminator: "radarData")]
+    public class Data {
         /// <summary>
         /// Gets or sets the labels.
         /// </summary>
@@ -24,5 +28,20 @@
         [JsonPropertyName("labels")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string> Labels { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Data for Charts
+    /// </summary>
+    public class Data<T> : Data where T : class {
+        /// <summary>
+        /// Gets or sets the datasets.
+        /// </summary>
+        /// <value>
+        /// The datasets.
+        /// </value>
+        [JsonPropertyName("datasets")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<T> Datasets { get; set; } = new List<T>();
     }
 }

--- a/src/Models/Common/Data.cs
+++ b/src/Models/Common/Data.cs
@@ -18,6 +18,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
     [JsonDerivedType(typeof(PieData), typeDiscriminator: "pieData")]
     [JsonDerivedType(typeof(PolarData), typeDiscriminator: "polarData")]
     [JsonDerivedType(typeof(RadarData), typeDiscriminator: "radarData")]
+    [JsonDerivedType(typeof(BubbleData), typeDiscriminator: "bubbleData")]
+    [JsonDerivedType(typeof(ScatterData), typeDiscriminator: "scatterData")]
     public class Data {
         /// <summary>
         /// Gets or sets the labels.

--- a/src/Models/Common/Dataset.cs
+++ b/src/Models/Common/Dataset.cs
@@ -1,10 +1,24 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
+﻿using PSC.Blazor.Components.Chartjs.Models.Bar;
+using PSC.Blazor.Components.Chartjs.Models.Bubble;
+using PSC.Blazor.Components.Chartjs.Models.Doughnut;
+using PSC.Blazor.Components.Chartjs.Models.Line;
+using PSC.Blazor.Components.Chartjs.Models.Pie;
+using PSC.Blazor.Components.Chartjs.Models.Polar;
+using PSC.Blazor.Components.Chartjs.Models.Radar;
+using PSC.Blazor.Components.Chartjs.Models.Scatter;
+
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Datatset for charts
     /// </summary>
-    public class Dataset
-    {
+    [JsonDerivedType(typeof(Dataset), typeDiscriminator: "base")]
+    [JsonDerivedType(typeof(BarDataset), typeDiscriminator: "barDataset")]
+    [JsonDerivedType(typeof(DoughnutDataset), typeDiscriminator: "doughnutDataset")]
+    [JsonDerivedType(typeof(LineDataset), typeDiscriminator: "lineDataset")]
+    [JsonDerivedType(typeof(PieDataset), typeDiscriminator: "pieDataset")]
+    [JsonDerivedType(typeof(PolarDataset), typeDiscriminator: "polarDataset")]
+    [JsonDerivedType(typeof(RadarDataset), typeDiscriminator: "radarDataset")]
+    public class Dataset {
         /// <summary>
         /// Gets or sets the data.
         /// </summary>

--- a/src/Models/Common/Dataset.cs
+++ b/src/Models/Common/Dataset.cs
@@ -7,7 +7,8 @@ using PSC.Blazor.Components.Chartjs.Models.Polar;
 using PSC.Blazor.Components.Chartjs.Models.Radar;
 using PSC.Blazor.Components.Chartjs.Models.Scatter;
 
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Datatset for charts
     /// </summary>
@@ -18,7 +19,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
     [JsonDerivedType(typeof(PieDataset), typeDiscriminator: "pieDataset")]
     [JsonDerivedType(typeof(PolarDataset), typeDiscriminator: "polarDataset")]
     [JsonDerivedType(typeof(RadarDataset), typeDiscriminator: "radarDataset")]
-    public class Dataset {
+    public class Dataset 
+    {
         /// <summary>
         /// Gets or sets the data.
         /// </summary>

--- a/src/Models/Common/Interaction.cs
+++ b/src/Models/Common/Interaction.cs
@@ -1,8 +1,10 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common {
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Class Interaction.
     /// </summary>
-    public class Interaction {
+    public class Interaction 
+    {
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="Interaction"/> is intersect.
         /// If true, the interaction mode only applies when the mouse position intersects an item on the chart.
@@ -25,7 +27,8 @@
         /// </summary>
         /// <value>The mode.</value>
         [JsonIgnore]
-        public InteractionMode? Mode {
+        public InteractionMode? Mode 
+        {
             get => _mode;
             set {
                 _mode = value;
@@ -51,7 +54,8 @@
         /// </summary>
         /// <value>The axis.</value>
         [JsonIgnore]
-        public AxisInteractions? Axis {
+        public AxisInteractions? Axis 
+        {
             get => _axis;
             set {
                 _axis = value;

--- a/src/Models/Common/Interaction.cs
+++ b/src/Models/Common/Interaction.cs
@@ -1,10 +1,8 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Class Interaction.
     /// </summary>
-    public class Interaction
-    {
+    public class Interaction {
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="Interaction"/> is intersect.
         /// If true, the interaction mode only applies when the mouse position intersects an item on the chart.
@@ -27,11 +25,9 @@
         /// </summary>
         /// <value>The mode.</value>
         [JsonIgnore]
-        public InteractionMode? Mode
-        {
+        public InteractionMode? Mode {
             get => _mode;
-            set
-            {
+            set {
                 _mode = value;
                 ModeString = _mode.Value;
             }
@@ -55,11 +51,9 @@
         /// </summary>
         /// <value>The axis.</value>
         [JsonIgnore]
-        public AxisInteractions? Axis
-        {
+        public AxisInteractions? Axis {
             get => _axis;
-            set
-            {
+            set {
                 _axis = value;
                 AxisString = _axis.Value;
             }

--- a/src/Models/Common/Legend.cs
+++ b/src/Models/Common/Legend.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Legend
     /// </summary>
@@ -16,7 +17,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
         /// The align.
         /// </value>
         [JsonIgnore]
-        public Align? Align {
+        public Align? Align 
+        {
             get => _align;
             set {
                 _align = value;
@@ -69,7 +71,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
         /// The position.
         /// </value>
         [JsonIgnore]
-        public LegendPosition Position {
+        public LegendPosition Position 
+        {
             get => _legendPosition;
             set {
                 _legendPosition = value;
@@ -109,7 +112,8 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common {
         /// </summary>
         /// <value>The text direction.</value>
         [JsonIgnore]
-        public TextDirection TextDirection {
+        public TextDirection TextDirection 
+        {
             get => _textDirection;
             set {
                 _textDirection = value;

--- a/src/Models/Common/Legend.cs
+++ b/src/Models/Common/Legend.cs
@@ -1,28 +1,24 @@
 ﻿using System.Threading.Tasks;
 
-namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Legend
     /// </summary>
-    public class Legend
-    {
+    public class Legend {
         private Align? _align;
         private LegendPosition _legendPosition;
         private TextDirection _textDirection;
 
-        /// <summary>
+        /// <summary>]
         /// Gets or sets the align. <seealso cref="Common.Align"/>
         /// </summary>
         /// <value>
         /// The align.
         /// </value>
         [JsonIgnore]
-        public Align? Align
-        {
+        public Align? Align {
             get => _align;
-            set
-            {
+            set {
                 _align = value;
                 AlignString = _align.Value;
             }
@@ -58,6 +54,14 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? FullSize { get; set; }
 
+        ///<summary>
+        /// Gets or sets the legend labels configuration
+        ///</summary>
+        ///<value>The Legend label configuration</value>
+        [JsonPropertyName("labels")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public LegendLabels Labels { get; set; }
+
         /// <summary>
         /// Gets or sets the position.
         /// </summary>
@@ -65,11 +69,9 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common
         /// The position.
         /// </value>
         [JsonIgnore]
-        public LegendPosition Position
-        {
+        public LegendPosition Position {
             get => _legendPosition;
-            set
-            {
+            set {
                 _legendPosition = value;
                 PositionString = value.Value;
             }
@@ -107,11 +109,9 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common
         /// </summary>
         /// <value>The text direction.</value>
         [JsonIgnore]
-        public TextDirection TextDirection
-        {
+        public TextDirection TextDirection {
             get => _textDirection;
-            set
-            {
+            set {
                 _textDirection = value;
                 TextDirectionString = value.Value;
             }
@@ -139,5 +139,6 @@ namespace PSC.Blazor.Components.Chartjs.Models.Common
         /// <value>The on legend click asynchronous.</value>
         [JsonIgnore]
         public Func<LegendClickContext, ValueTask>? OnClickAsync { get; set; }
+
     }
 }

--- a/src/Models/Common/LegendItem.cs
+++ b/src/Models/Common/LegendItem.cs
@@ -1,0 +1,45 @@
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
+    /// <summary>
+    /// Legend Item
+    /// </summary>
+    public class LegendItem {
+        //https://www.chartjs.org/docs/latest/configuration/legend.html#legend-item-interface
+
+        [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Text { get; set; }
+        [JsonPropertyName("borderRadius")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? BorderRadius { get; set; }
+        [JsonPropertyName("datasetIndex")]
+        public int DatasetIndex { get; set; }
+        [JsonPropertyName("fillStyle")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FillStyle { get; set; }
+        [JsonPropertyName("fontColor")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FontColor { get; set; }
+        [JsonPropertyName("hidden")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Hidden { get; set; }
+        [JsonPropertyName("lineCap")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LineCap { get; set; }
+        [JsonPropertyName("lineDash")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<decimal?>? LineDash { get; set; }
+        [JsonPropertyName("lineDashOffset")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? LineDashOffset { get; set; }
+        [JsonPropertyName("lineJoin")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LineJoin { get; set; }
+        [JsonPropertyName("lineWidth")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public decimal? LineWidth { get; set; }
+        [JsonPropertyName("rotation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? Rotation { get; set; }
+
+    }
+}

--- a/src/Models/Common/LegendItem.cs
+++ b/src/Models/Common/LegendItem.cs
@@ -1,8 +1,10 @@
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Legend Item
     /// </summary>
-    public class LegendItem {
+    public class LegendItem 
+    {
         //https://www.chartjs.org/docs/latest/configuration/legend.html#legend-item-interface
 
         [JsonPropertyName("text")]

--- a/src/Models/Common/LegendLabels.cs
+++ b/src/Models/Common/LegendLabels.cs
@@ -1,0 +1,27 @@
+namespace PSC.Blazor.Components.Chartjs.Models.Common {
+    /// <summary>
+    /// Legend Label Configuration
+    /// </summary>
+    public class LegendLabels {
+        //https://www.chartjs.org/docs/latest/configuration/legend.html#legend-label-configuration
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has filter.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has filter; otherwise, <c>false</c>.
+        /// </value>
+        [JsonInclude]
+        [JsonPropertyName("hasFilter")]
+        public bool HasFilter => Filter != null;
+
+        /// <summary>
+        /// Gets or sets the filter.
+        /// </summary>
+        /// <value>
+        /// The filter.
+        /// </value>
+        [JsonIgnore]
+        public Func<LegendFilterContext, bool?>? Filter { get; set; }
+    }
+}

--- a/src/Models/Common/LegendLabels.cs
+++ b/src/Models/Common/LegendLabels.cs
@@ -1,8 +1,10 @@
-namespace PSC.Blazor.Components.Chartjs.Models.Common {
+namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Legend Label Configuration
     /// </summary>
-    public class LegendLabels {
+    public class LegendLabels 
+    {
         //https://www.chartjs.org/docs/latest/configuration/legend.html#legend-label-configuration
 
         /// <summary>

--- a/src/Models/Common/Ticks.cs
+++ b/src/Models/Common/Ticks.cs
@@ -1,8 +1,10 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common {
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Common 
+{
     /// <summary>
     /// Ticks
     /// </summary>
-    public class Ticks {
+    public class Ticks 
+    {
         /// <summary>
         /// Gets or sets the call back.
         /// </summary>
@@ -30,7 +32,8 @@
         /// The cross align
         /// </value>
         [JsonIgnore]
-        public CrossAlign? CrossAlign {
+        public CrossAlign? CrossAlign 
+        {
             get => _crossAlign;
             set {
                 _crossAlign = value;

--- a/src/Models/Common/Ticks.cs
+++ b/src/Models/Common/Ticks.cs
@@ -82,6 +82,7 @@
         public int? MinRotation { get; set; }
 
         ///<summary>
+        /// Gets or sets the Auto skip.
         /// If true, automatically calculates how many labels can be shown and hides labels accordingly. 
         /// Labels will be rotated up to maxRotation before skipping any. Turn autoSkip off to show all labels no matter what.
         ///</summary>

--- a/src/Models/Common/Ticks.cs
+++ b/src/Models/Common/Ticks.cs
@@ -1,10 +1,8 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Common
-{
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Common {
     /// <summary>
     /// Ticks
     /// </summary>
-    public class Ticks
-    {
+    public class Ticks {
         /// <summary>
         /// Gets or sets the call back.
         /// </summary>
@@ -32,11 +30,9 @@
         /// The cross align
         /// </value>
         [JsonIgnore]
-        public CrossAlign? CrossAlign
-        {
+        public CrossAlign? CrossAlign {
             get => _crossAlign;
-            set
-            {
+            set {
                 _crossAlign = value;
                 CrossAlignString = _crossAlign.Value;
             }
@@ -52,6 +48,10 @@
         [JsonPropertyName("crossAlign")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? CrossAlignString { get; set; }
+
+        [JsonPropertyName("font")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Font? Font { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum rotation.
@@ -80,6 +80,17 @@
         [JsonPropertyName("minRotation")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? MinRotation { get; set; }
+
+        ///<summary>
+        /// If true, automatically calculates how many labels can be shown and hides labels accordingly. 
+        /// Labels will be rotated up to maxRotation before skipping any. Turn autoSkip off to show all labels no matter what.
+        ///</summary>
+        ///<value>
+        /// The auto skip
+        ///</value>
+        [JsonPropertyName("autoSkip")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? AutoSkip { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the step. 

--- a/src/Models/Doughnut/DoughnutDataset.cs
+++ b/src/Models/Doughnut/DoughnutDataset.cs
@@ -1,11 +1,9 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Doughnut
-{
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Doughnut {
     /// <summary>
     /// Doughnut Dataset
     /// </summary>
     /// <seealso cref="PSC.Blazor.Components.Chartjs.Models.Common.Dataset" />
-    public class DoughnutDataset : Dataset
-    {
+    public class DoughnutDataset : Dataset {
         /// <summary>
         /// Gets or sets the color of the background.
         /// </summary>

--- a/src/Models/Doughnut/DoughnutDataset.cs
+++ b/src/Models/Doughnut/DoughnutDataset.cs
@@ -1,9 +1,11 @@
-﻿namespace PSC.Blazor.Components.Chartjs.Models.Doughnut {
+﻿namespace PSC.Blazor.Components.Chartjs.Models.Doughnut 
+{
     /// <summary>
     /// Doughnut Dataset
     /// </summary>
     /// <seealso cref="PSC.Blazor.Components.Chartjs.Models.Common.Dataset" />
-    public class DoughnutDataset : Dataset {
+    public class DoughnutDataset : Dataset 
+    {
         /// <summary>
         /// Gets or sets the color of the background.
         /// </summary>

--- a/src/PSC.Blazor.Components.Chartjs.csproj
+++ b/src/PSC.Blazor.Components.Chartjs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>ChartJs component for Blazor. Compatible with client-side and server-side Blazor applications.</Description>
     <PackageIcon>psc_logo.png</PackageIcon>

--- a/src/wwwroot/Chart.js
+++ b/src/wwwroot/Chart.js
@@ -4,7 +4,9 @@
     "pie": "pieData",
     "doughnut": "doughnutData",
     "radar": "radarData",
-    "polarArea": "polarData"
+    "polarArea": "polarData",
+    "bubble": "bubbleData",
+    "scatter": "scatterData"
 };
 
 function crosshairLine(chart, evt, plugin) {

--- a/src/wwwroot/Chart.js
+++ b/src/wwwroot/Chart.js
@@ -54,6 +54,15 @@ export function chartSetup(id, dotnetConfig, jsonConfig) {
 
     var context2d = document.getElementById(id).getContext('2d');
     let config = eval(jsonConfig);
+
+    if (config?.options?.plugins?.legend?.labels?.hasFilter) {
+        config.options.plugins.legend.labels.hasFilter = undefined;
+        config.options.plugins.legend.labels.filter = function (item, data) {
+            return DotNet.invokeMethod('PSC.Blazor.Components.Chartjs', 'LegendLabelsFilter',
+                dotnetConfig, item, data)
+        };
+    }
+
     if (config?.options?.plugins?.tooltip?.callbacks?.hasLabel) {
         config.options.plugins.tooltip.callbacks.hasLabel = undefined;
         config.options.plugins.tooltip.callbacks.label = function (ctx) {

--- a/src/wwwroot/Chart.js
+++ b/src/wwwroot/Chart.js
@@ -1,4 +1,13 @@
-﻿function crosshairLine(chart, evt, plugin) {
+﻿const DATA_TYPES = {
+    "bar": "barData",
+    "line": "lineData",
+    "pie": "pieData",
+    "doughnut": "doughnutData",
+    "radar": "radarData",
+    "polarArea": "polarData"
+};
+
+function crosshairLine(chart, evt, plugin) {
     const { canvas, ctx, chartArea: { left, right, top, bottom } } = chart;
 
     chart.update("none");
@@ -58,8 +67,15 @@ export function chartSetup(id, dotnetConfig, jsonConfig) {
     if (config?.options?.plugins?.legend?.labels?.hasFilter) {
         config.options.plugins.legend.labels.hasFilter = undefined;
         config.options.plugins.legend.labels.filter = function (item, data) {
+            let json = JSON.stringify(data);
+            let jsonArray = [...json];
+
+            let dataType = DATA_TYPES[jsonConfig.type];
+            jsonArray.splice(1, 0, `"$type":"${dataType}",`);
+            json = jsonArray.join("");
+
             return DotNet.invokeMethod('PSC.Blazor.Components.Chartjs', 'LegendLabelsFilter',
-                dotnetConfig, item, data)
+                dotnetConfig, item, JSON.parse(json))
         };
     }
 


### PR DESCRIPTION
I'm working on a project that utilizes BlazorChartJs and during my coding sessions I discovered that some properties and functionalities  were not available in BlazorChartJs. These functionalities are:

### [1] Legend Labels Filtering e.g:

```Javascript

legend: {
      display: true,
      labels: {
           filter: function(legendItem, data) {
                return legendItem.index != 1 
           }
      }
 }
```

### [2] Scales Ticks' AutoSkip and Font properties e.g:

```Javascript

scales: {
    yAxes: [{
        ticks: {
          color: "black",
          autoSkip: false
        }
      }],
    xAxes: [{
        ticks: {
          color: "red",
          font: 14
        }
      }]
  }
```
I've implemented these functionalities following the project structure, but the .NET version needed to be updated to .NET 7 because System.Text.Json in .NET 6 can't handle polymorphic entities. This feature is important to enable the _LegendFilterContext_ to receive generic data that can be parsed into the correct type of chart data.

*OBS*:
I use a different type of formatting in my personal projects, and I had not noticed that my formatting was different from yours. Therefore, I had to fix this in the commit _8361ad61840bad553b945dc07c78a48b8623f0af_